### PR TITLE
Add support for standard main menu

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,6 +12,14 @@ pygmentsUseClasses = true
   dark = "auto"
   highlight = true
 
+[menu]
+  [[menu.main]]
+    identifier = "about"
+    name = "about"
+    title = "about"
+    url = "/about/"
+    weight = 20
+
 [permalinks]
   posts = "/:title/"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,6 +14,13 @@ pygmentsUseClasses = true
 
 [menu]
   [[menu.main]]
+    identifier = "posts"
+    name = "posts"
+    title = "posts"
+    url = "/"
+    weight = 10
+
+  [[menu.main]]
     identifier = "about"
     name = "about"
     title = "about"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,6 +8,11 @@
                 <a href="{{ .Permalink }}">{{ .Title }}</a>
             </li>
             {{ end }}
+            {{ range .Site.Menus.main.ByWeight }}
+            <li>
+                {{ .Pre }}<a href="{{ .URL }}" title="{{ .Title }}">{{- .Name -}}</a>{{ .Post }}
+            </li>
+            {{ end }}
         </ul>
     </nav>
 </header>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,12 +2,6 @@
     <h2><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h2>
     <nav>
         <ul>
-            <li><a href="{{ .Site.BaseURL }}">posts</a></li>
-            {{ range where .Site.Home.Pages "Title" "!=" "Posts" }}
-            <li>
-                <a href="{{ .Permalink }}">{{ .Title }}</a>
-            </li>
-            {{ end }}
             {{ range .Site.Menus.main.ByWeight }}
             <li>
                 {{ .Pre }}<a href="{{ .URL }}" title="{{ .Title }}">{{- .Name -}}</a>{{ .Post }}


### PR DESCRIPTION
Love the theme. This allows main menu elements in the standard Hugo config format: https://gohugo.io/templates/menu-templates/#site-config-menus