### PR TITLE
Add Netlify installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ $ hugo server -t etch
 ```
 
 Read the [wiki](https://github.com/LukasJoswiak/etch/wiki) to learn about more options.
+
+***Note**: if you are using Netlify to host your site, you must [add Etch as a submodule](https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#use-hugo-themes-with-netlify) instead of cloning.*


### PR DESCRIPTION
As pointed out by #8, Etch must be installed as a submodule (instead of cloning) when using Netlify to deploy a Hugo site. This PR adds a note in the installation instructions pointing to the [official Hugo instructions on hosting a site on Netlify](https://gohugo.io/hosting-and-deployment/hosting-on-netlify).