### PR TITLE
Simple Blocksquotes CSS Style

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -229,6 +229,15 @@ main#content figure figcaption p {
     padding-left: 8px;
 }
 
+main#content blockquote {
+    font-style: italic;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 50px;
+    padding-left: 15px;
+    border-left: 3px solid #ccc;
+}
+
 main#content code,
 main#content pre {
     font-family: 'Menlo', monospace;


### PR DESCRIPTION
I really enjoy the minimalistic nature of the theme but realized that there is no actual blockquotes styling, instead relying on the browser to automatically indent it. The browser doesn't auto-italicize the quotes either which is kind of annoying. 

While indentation is good I implemented a CSS style that is inline with the simple nature of the theme that highlights blockquotes better. Works in both dark & light modes. See images below:

<img width="574" alt="blockquote-dark" src="https://user-images.githubusercontent.com/39282962/112232265-a6c08e00-8c0e-11eb-8ad5-0e65ffd155f3.png">

~

<img width="582" alt="blockquote-light" src="https://user-images.githubusercontent.com/39282962/112232267-a6c08e00-8c0e-11eb-8302-0c83d5b5c02b.png">

