### PR TITLE
Add taxonomies

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,0 +1,6 @@
+<li>
+    <a href="{{ .Permalink }}">
+        {{ .Title }}
+        <small><time>{{ .Date.Format "Jan 2, 2006" }}</time></small>
+    </a>
+</li>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+<h3>{{ .Title }}</h3>
+<ul id="posts">
+{{- range .Pages }}
+    {{ .Render "li" }}
+{{- end }}
+</ul>
+{{ end }}

--- a/layouts/partials/posts.html
+++ b/layouts/partials/posts.html
@@ -1,11 +1,6 @@
 <h3>Posts</h3>
 <ul id="posts">
 {{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
-    <li>
-        <a href="{{ .Permalink }}">
-            {{ .Title }}
-            <small><time>{{ .Date.Format "Jan 2, 2006" }}</time></small>
-        </a>
-    </li>
+    {{ .Render "li" }}
 {{- end }}
 </ul>


### PR DESCRIPTION
Adds taxonomy support as described at https://gohugo.io/content-management/taxonomies/.

Taxonomies are a way to categorize content with labels. Hugo enables the `tags` and `categories` taxonomies by default. This change adds a new `/<taxonomy/` page with a list of all labels for that taxonomy. For example, adding `tags: ['writing', 'mystery']` to the front matter of a post and then visiting `example.com/tags/` will show the `writing` and `mystery` tags.