### PR TITLE
Add support for last modified date

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -43,7 +43,7 @@ main#content ul#posts li a:hover {
     color: #21c7ff;
 }
 
-main#content header#post-header time {
+main#content header#post-header div {
     color: #a7a7a7;
 }
 {{- if not (eq .Site.Params.dark "on") -}}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -142,7 +142,7 @@ main#content header#post-header h1 {
     line-height: 1.15;
 }
 
-main#content header#post-header time {
+main#content header#post-header div {
     display: block;
     font-size: 0.85em;
     color: #767676;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,9 +2,15 @@
 <article>
     <header id="post-header">
         <h1>{{ .Title }}</h1>
-        {{- if isset .Params "date" -}}
-            <time>{{ .Date.Format "January 2, 2006" }}</time>
-        {{- end -}}
+            <div>
+            {{- if isset .Params "date" -}}
+                {{ if eq .Lastmod .Date }}
+                <time>{{ .Date.Format "January 2, 2006" }}</time>
+                {{ else }}
+                Updated <time>{{ .Lastmod.Format "January 2, 2006" }}</time>
+                {{ end }}
+            {{- end -}}
+            </div>
     </header>
     {{- .Content -}}
 </article>


### PR DESCRIPTION
If `lastmod` is specified in the front matter for a post, and `lastmod != date`, the post will display `Updated <lastmod>` instead of showing the original publication date.