### PR TITLE
Fix bug where page title was not showing up properly

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,5 +27,5 @@
     {{ $css := $resources | resources.Concat "css/style.css" | minify }}
     {{ printf `<link rel="stylesheet" href="%s">` $css.RelPermalink | safeHTML }}
 
-    <title>{{ .Title }}</title>
+    <title>{{ .Site.Title }}</title>
 </head>


### PR DESCRIPTION
The param `Title` was not being properly read