### PR TITLE
Fix modification date displaying as original date

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
             {{ if eq .Lastmod .Date }}
                 <time>{{ .Date | time.Format (i18n "post.created") }}</time>
             {{ else }}
-                <time>{{ .Date | time.Format (i18n "post.updated") }}</time>
+                <time>{{ .Lastmod | time.Format (i18n "post.updated") }}</time>
             {{ end }}
         {{- end -}}
         </div>


### PR DESCRIPTION
When `lastmod` is specified, a post will indicate that it was updated, but it incorrectly uses the original date instead of the modification date.