### PR TITLE
Example site: remove shortcode instagram_simple

### DIFF
--- a/exampleSite/content/posts/rich-content.md
+++ b/exampleSite/content/posts/rich-content.md
@@ -13,14 +13,6 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 <!--more-->
 ---
 
-## Instagram Simple Shortcode
-
-{{< instagram_simple BGvuInzyFAe hidecaption >}}
-
-<br>
-
----
-
 ## YouTube Privacy Enhanced Shortcode
 
 {{< youtube ZJthWmvUzzc >}}


### PR DESCRIPTION
It would be appreciated if you could accept removing shortcode instagram_simple.

Because this shortcode uses a deprecated API, see this https://github.com/gohugoio/hugo/issues/7879#issuecomment-716058575 for details or https://gohugo.io/content-management/shortcodes/#example-instagram-display.

Since this shortcode doesn't work on the [live demo site](https://lukasjoswiak.github.io/etch/rich-content/) of the theme either, I removed the shortcode.