### PR TITLE
Fixes: fix twitter shortcode warning

### DIFF
--- a/exampleSite/content/posts/rich-content.md
+++ b/exampleSite/content/posts/rich-content.md
@@ -29,9 +29,9 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Simple Shortcode
+## Twitter Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 


### PR DESCRIPTION
As per[ conversation](https://github.com/LukasJoswiak/etch/pull/34), create PR to fix twitter shortcode warning when building site.

fixed shortcode works as below:
<img width="472" alt="Screen Shot 2022-03-27 at 13 42 04" src="https://user-images.githubusercontent.com/61895076/160267211-43156eb3-b513-4681-b015-ff6a08d8397b.png">

