### PR TITLE
Point to the localized root on website's name

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header id="banner">
-    <h2><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h2>
+    <h2><a href="{{ "/" | absLangURL }}">{{ .Site.Title }}</a></h2>
     <nav>
         <ul>
             {{ range .Site.Menus.main.ByWeight -}}


### PR DESCRIPTION
This should work, at least in theory. 
I'm quite new to Hugo, so maybe I should have used .Site.Home.Permalink, I don't know if that does even matter, or if the homepage is always in the root folder as a sane person would assume. In any case, this mimics the old behavior.