### PR TITLE
Add possibility to extend the content of the head tag

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -13,5 +13,9 @@
         </div>
     </header>
     {{- .Content -}}
+
+    {{- if (.Param "comments") }}
+    {{- partial "comments.html" . }}
+    {{- end }}
 </article>
 {{ end }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,3 @@
+{{- /* Comments area start */ -}}
+{{- /* to add comments read => https://gohugo.io/content-management/comments/ */ -}}
+{{- /* Comments area end */ -}}

--- a/layouts/partials/extended_head.html
+++ b/layouts/partials/extended_head.html
@@ -1,0 +1,4 @@
+{{- /* Head custom content area start */ -}}
+{{- /*     Insert any custom code (web-analytics, resources, etc.) - it will appear in the <head></head> section of every page. */ -}}
+{{- /*     Can be overwritten by partial with the same name in the global layouts. */ -}}
+{{- /* Head custom content area end */ -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,4 +28,7 @@
     {{ printf `<link rel="stylesheet" href="%s">` $css.RelPermalink | safeHTML }}
 
     <title>{{ .Title }}</title>
+
+    {{- partial "extend_head.html" . -}}
+    
 </head>


### PR DESCRIPTION
This can be helpful if the user needs to inject code into <head>.