### PR TITLE
Wrap long strings to prevent horizontal scroll

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -15,6 +15,7 @@ body {
     margin: 0 auto;
     padding: 0 16px;
     line-height: 1.6;
+    overflow-wrap: break-word;
 }
 
 header#banner {


### PR DESCRIPTION
This is mainly useful for long URLs which could otherwise cause a horizontal scroll bar to appear on low width screens.