### PR TITLE
Fix CSS footnote selector

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -268,7 +268,7 @@ main#content pre code {
     padding: 0;
 }
 
-main#content section.footnotes {
+main#content .footnotes {
     font-size: 0.9em;
 }
 


### PR DESCRIPTION
It appears a recent version of hugo changed the HTML generated for footnotes. They used to be inside a `section` tag with the `footnotes` class. They are now in a `div` with the `footnotes` class.