### PR TITLE
Meta Description Update

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,11 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="{{ or .Description .Site.Params.description "My Hugo Site" }}">
+
+    {{ if or .Description .Site.Params.description -}}
+    <meta name="description" content="{{ or .Description .Site.Params.description }}">
+    {{ end -}}
+
     {{ printf `<link rel="shortcut icon" href="%s">` ("favicon.ico" | absURL) | safeHTML }}
     {{ with .OutputFormats.Get "rss" -}}
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,9 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ with .Site.Params.description -}}
-    <meta name="description" content="{{ . }}">
-    {{ end }}
+    <meta name="description" content="{{ or .Description .Site.Params.description "My Hugo Site" }}">
     {{ printf `<link rel="shortcut icon" href="%s">` ("favicon.ico" | absURL) | safeHTML }}
     {{ with .OutputFormats.Get "rss" -}}
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
The current HEAD of the Etch template allows you to set a site wide description tag via the "description" config parameter. However I think it would be good to have the option of having a separate description for the posts.

In my preliminary pull request I have set a default fallback of "My Hugo Site". I am happy if people want to set this differently. 